### PR TITLE
Fix load tests by increasing decline threshold

### DIFF
--- a/cmd/paymentsvc/main.go
+++ b/cmd/paymentsvc/main.go
@@ -25,7 +25,7 @@ func main() {
 	var (
 		port          = flag.String("port", "8080", "Port to bind HTTP listener")
 		zip           = flag.String("zipkin", os.Getenv("ZIPKIN"), "Zipkin address")
-		declineAmount = flag.Float64("decline", 100, "Decline payments over certain amount")
+		declineAmount = flag.Float64("decline", 105, "Decline payments over certain amount")
 	)
 	flag.Parse()
 	var tracer stdopentracing.Tracer


### PR DESCRIPTION
The load tests are flakey because we have a "payment declined" threshold
that triggers once the cart reaches $100. The most expensive product is
only $99.99 but with shipping cost it goes to $104.95

See https://github.com/microservices-demo/microservices-demo/issues/752

---
This PR increases this threshold to $105.

Output from running the load-tests
```
 3 POST /orders: "HTTPError(u'406 Client Error: Not Acceptable for url: http://localhost/orders',)"                                                                 
```

Error log in `docker logs dockercompose_orders_1`
```
2017-11-20 14:54:25.666  INFO [orders,c01f7ca76e5aa1f6,9a3ce64492c3be40,true] 7 --- [p-nio-80-exec-1] w.w.s.o.controllers.OrdersController     : Received payment response: PaymentResponse{authorised=false, message=Payment declined: amount exceeds 100.00}
```