### PR TITLE
Avoid granting Linux capabilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ default: test
 
 copy:
 	docker create --name $(INSTANCE) $(NAME)-dev
-	docker cp $(INSTANCE):/app/main $(shell pwd)/app
+	docker cp $(INSTANCE):/app $(shell pwd)/app
 	docker rm $(INSTANCE)
 
 release:

--- a/docker/payment/Dockerfile
+++ b/docker/payment/Dockerfile
@@ -1,13 +1,29 @@
 FROM golang:1.7
 
-RUN mkdir /app
 COPY . /go/src/github.com/microservices-demo/payment/
 
 RUN go get -u github.com/FiloSottile/gvt
 RUN cd /go/src/github.com/microservices-demo/payment/ && gvt restore
 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /app/main github.com/microservices-demo/payment/cmd/paymentsvc
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /app github.com/microservices-demo/payment/cmd/paymentsvc
 
-CMD ["/app/main", "-port=80"]
+FROM alpine:3.4
 
-#EXPOSE 80
+WORKDIR /
+COPY --from=0 /app /app
+
+ENV	SERVICE_USER=myuser \
+	SERVICE_UID=10001 \
+	SERVICE_GROUP=mygroup \
+	SERVICE_GID=10001
+
+RUN	addgroup -g ${SERVICE_GID} ${SERVICE_GROUP} && \
+	adduser -g "${SERVICE_NAME} user" -D -H -G ${SERVICE_GROUP} -s /sbin/nologin -u ${SERVICE_UID} ${SERVICE_USER} && \
+	chmod +x /app && \
+    chown -R ${SERVICE_USER}:${SERVICE_GROUP} /app
+
+USER ${SERVICE_USER}
+
+CMD ["/app", "-port=8080"]
+
+EXPOSE 8080

--- a/docker/payment/Dockerfile-release
+++ b/docker/payment/Dockerfile-release
@@ -1,5 +1,8 @@
 FROM alpine:3.4
 
+WORKDIR /
+COPY app /
+
 ENV	SERVICE_USER=myuser \
 	SERVICE_UID=10001 \
 	SERVICE_GROUP=mygroup \
@@ -7,16 +10,11 @@ ENV	SERVICE_USER=myuser \
 
 RUN	addgroup -g ${SERVICE_GID} ${SERVICE_GROUP} && \
 	adduser -g "${SERVICE_NAME} user" -D -H -G ${SERVICE_GROUP} -s /sbin/nologin -u ${SERVICE_UID} ${SERVICE_USER} && \
-	apk add --update libcap
-
-WORKDIR /
-EXPOSE 80
-COPY app /
-
-RUN	chmod +x /app && \
-	chown -R ${SERVICE_USER}:${SERVICE_GROUP} /app && \
-	setcap 'cap_net_bind_service=+ep' /app
+	chmod +x /app && \
+    chown -R ${SERVICE_USER}:${SERVICE_GROUP} /app
 
 USER ${SERVICE_USER}
 
-CMD ["/app", "-port=80"]
+CMD ["/app", "-port=8080"]
+
+EXPOSE 8080

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -30,6 +30,6 @@ REPO=${GROUP}/$(basename payment);
 
 $DOCKER_CMD build -t ${REPO}-dev -f $CODE_DIR/docker/payment/Dockerfile $CODE_DIR/docker/payment;
 $DOCKER_CMD create --name payment ${REPO}-dev;
-$DOCKER_CMD cp payment:/app/main $CODE_DIR/docker/payment/app;
+$DOCKER_CMD cp payment:/app $CODE_DIR/docker/payment/app;
 $DOCKER_CMD rm payment;
 $DOCKER_CMD build -t ${REPO}:${COMMIT} -f $CODE_DIR/docker/payment/Dockerfile-release $CODE_DIR/docker/payment;

--- a/test/container.py
+++ b/test/container.py
@@ -22,6 +22,7 @@ class PaymentContainerTest(unittest.TestCase):
                    '-d',
                    '--name', PaymentContainerTest.container_name,
                    '-h', 'payment',
+                   '-p', '80:8080',
                    'weaveworksdemos/payment-dev:' + self.TAG]
         Docker().execute(command)
         self.ip = Docker().get_container_ip(PaymentContainerTest.container_name)

--- a/test/container.py
+++ b/test/container.py
@@ -32,14 +32,14 @@ class PaymentContainerTest(unittest.TestCase):
 
     def test_api_validated(self):
         limit = 30
-        while Api().noResponse('http://' + self.ip + ':8080/payments/'):
+        while Api().noResponse('http://' + self.ip + ':80/payments/'):
             if limit == 0:
                 self.fail("Couldn't get the API running")
             limit = limit - 1
             sleep(1)
         
         out = Dredd().test_against_endpoint("payment",
-                                            'http://' + self.ip + ':8080/',
+                                            'http://' + self.ip + ':80/',
                                             links=[self.container_name],
                                             dump_streams=True)
         

--- a/test/container.py
+++ b/test/container.py
@@ -11,6 +11,7 @@ from util.Dredd import Dredd
 
 class PaymentContainerTest(unittest.TestCase):
     TAG = "latest"
+    PORT = "80"
     container_name = Docker().random_container_name('payment')
 
     def __init__(self, methodName='runTest'):
@@ -22,8 +23,8 @@ class PaymentContainerTest(unittest.TestCase):
                    '-d',
                    '--name', PaymentContainerTest.container_name,
                    '-h', 'payment',
-                   '-p', '80:8080',
-                   'weaveworksdemos/payment-dev:' + self.TAG]
+                   'weaveworksdemos/payment-dev:' + self.TAG,
+                   '/app', '-port=' + PaymentContainerTest.PORT]
         Docker().execute(command)
         self.ip = Docker().get_container_ip(PaymentContainerTest.container_name)
 
@@ -32,14 +33,16 @@ class PaymentContainerTest(unittest.TestCase):
 
     def test_api_validated(self):
         limit = 30
-        while Api().noResponse('http://' + self.ip + ':80/payments/'):
+        url = f'http://{self.ip}:{PaymentContainerTest.PORT}/'
+        
+        while Api().noResponse(url + 'payments/'):
             if limit == 0:
                 self.fail("Couldn't get the API running")
             limit = limit - 1
             sleep(1)
         
         out = Dredd().test_against_endpoint("payment",
-                                            'http://' + self.ip + ':80/',
+                                            url,
                                             links=[self.container_name],
                                             dump_streams=True)
         

--- a/test/container.py
+++ b/test/container.py
@@ -31,14 +31,14 @@ class PaymentContainerTest(unittest.TestCase):
 
     def test_api_validated(self):
         limit = 30
-        while Api().noResponse('http://' + self.ip + ':80/payments/'):
+        while Api().noResponse('http://' + self.ip + ':8080/payments/'):
             if limit == 0:
                 self.fail("Couldn't get the API running")
             limit = limit - 1
             sleep(1)
         
         out = Dredd().test_against_endpoint("payment",
-                                            'http://' + self.ip + ':80/',
+                                            'http://' + self.ip + ':8080/',
                                             links=[self.container_name],
                                             dump_streams=True)
         

--- a/test/container.py
+++ b/test/container.py
@@ -11,7 +11,8 @@ from util.Dredd import Dredd
 
 class PaymentContainerTest(unittest.TestCase):
     TAG = "latest"
-    PORT = "80"
+    PORT = "8080"
+
     container_name = Docker().random_container_name('payment')
 
     def __init__(self, methodName='runTest'):


### PR DESCRIPTION
My task was to run your Helm chart on K8s cluster with restrictive pod security policy. The worst problem I encountered was that you grant Linux capabilities in order to bind 80 port inside of container. As a result I was not able to run these images in any way without rebuilding them reverting this operation. That's why I propose you to use other port inside of containers and map it externally to 80 during running a container.