### PR TITLE
Avoid granting Linux capabilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ default: test
 
 copy:
 	docker create --name $(INSTANCE) $(NAME)-dev
-	docker cp $(INSTANCE):/app/main $(shell pwd)/app
+	docker cp $(INSTANCE):/app $(shell pwd)/app
 	docker rm $(INSTANCE)
 
 release:

--- a/docker/payment/Dockerfile
+++ b/docker/payment/Dockerfile
@@ -1,13 +1,29 @@
 FROM golang:1.7
 
-RUN mkdir /app
 COPY . /go/src/github.com/microservices-demo/payment/
 
 RUN go get -u github.com/FiloSottile/gvt
 RUN cd /go/src/github.com/microservices-demo/payment/ && gvt restore
 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /app/main github.com/microservices-demo/payment/cmd/paymentsvc
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /app github.com/microservices-demo/payment/cmd/paymentsvc
 
-CMD ["/app/main", "-port=80"]
+FROM alpine:3.4
 
-#EXPOSE 80
+WORKDIR /
+COPY --from=0 /app /app
+
+ENV	SERVICE_USER=myuser \
+	SERVICE_UID=10001 \
+	SERVICE_GROUP=mygroup \
+	SERVICE_GID=10001
+
+RUN	addgroup -g ${SERVICE_GID} ${SERVICE_GROUP} && \
+	adduser -g "${SERVICE_NAME} user" -D -H -G ${SERVICE_GROUP} -s /sbin/nologin -u ${SERVICE_UID} ${SERVICE_USER} && \
+	chmod +x /app && \
+    chown -R ${SERVICE_USER}:${SERVICE_GROUP} /app
+
+USER ${SERVICE_USER}
+
+CMD ["/app", "-port=8080"]
+
+EXPOSE 8080

--- a/docker/payment/Dockerfile-release
+++ b/docker/payment/Dockerfile-release
@@ -1,5 +1,8 @@
 FROM alpine:3.4
 
+WORKDIR /
+COPY app /
+
 ENV	SERVICE_USER=myuser \
 	SERVICE_UID=10001 \
 	SERVICE_GROUP=mygroup \
@@ -7,16 +10,11 @@ ENV	SERVICE_USER=myuser \
 
 RUN	addgroup -g ${SERVICE_GID} ${SERVICE_GROUP} && \
 	adduser -g "${SERVICE_NAME} user" -D -H -G ${SERVICE_GROUP} -s /sbin/nologin -u ${SERVICE_UID} ${SERVICE_USER} && \
-	apk add --update libcap
-
-WORKDIR /
-EXPOSE 80
-COPY app /
-
-RUN	chmod +x /app && \
-	chown -R ${SERVICE_USER}:${SERVICE_GROUP} /app && \
-	setcap 'cap_net_bind_service=+ep' /app
+	chmod +x /app && \
+    chown -R ${SERVICE_USER}:${SERVICE_GROUP} /app
 
 USER ${SERVICE_USER}
 
-CMD ["/app", "-port=80"]
+CMD ["/app", "-port=8080"]
+
+EXPOSE 8080

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -30,6 +30,6 @@ REPO=${GROUP}/$(basename payment);
 
 $DOCKER_CMD build -t ${REPO}-dev -f $CODE_DIR/docker/payment/Dockerfile $CODE_DIR/docker/payment;
 $DOCKER_CMD create --name payment ${REPO}-dev;
-$DOCKER_CMD cp payment:/app/main $CODE_DIR/docker/payment/app;
+$DOCKER_CMD cp payment:/app $CODE_DIR/docker/payment/app;
 $DOCKER_CMD rm payment;
 $DOCKER_CMD build -t ${REPO}:${COMMIT} -f $CODE_DIR/docker/payment/Dockerfile-release $CODE_DIR/docker/payment;


### PR DESCRIPTION
My task was to run your Helm chart on K8s cluster with restrictive pod security policy. The worst problem I encountered was that you grant Linux capabilities in order to bind 80 port inside of container. As a result I was not able to run these images in any way without rebuilding them reverting this operation. That's why I propose you to use other port inside of containers and map it externally to 80 during running a container.