### PR TITLE
add github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,96 @@
+name: ci
+
+on:
+  push:
+    branches:
+    - "*"  # run for branches
+    tags:
+    - "*"  # run for tags
+  pull_request:
+    branches:
+    - "*"  # run for branches
+    tags:
+    - "*"  # run for tags
+
+
+jobs:
+  test:
+    defaults:
+      run:
+        working-directory: go/src/github.com/microservices-demo/payment
+    runs-on: ubuntu-latest
+    env:
+      GROUP: weaveworksdemos 
+      COMMIT: ${{ github.sha }}
+      REPO: payment
+      GO_VERSION: 1.7
+      GOPATH: /home/runner/work/payment/payment/go/
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+        path: go/src/github.com/microservices-demo/payment
+
+
+    #
+    #
+    # Set up go
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.GO_VERSION }} # The Go version to download (if necessary) and use.
+
+    #
+    #
+    # Install prereqs
+    - name: Install prereqs
+      run: |
+        go get -u github.com/mattn/goveralls
+        go get -u github.com/FiloSottile/gvt
+        gvt restore
+
+    #
+    #
+    # Container build step
+    - name: Build
+      env:
+        DOCKER_BUILDKIT: 1
+      run: ./scripts/build.sh
+
+    #
+    #
+    # Unit test step
+    - name: Unit test
+      env:
+        DOCKER_BUILDKIT: 1
+      run: ./test/test.sh unit.py
+
+    #
+    #
+    # Container test step
+    - name: Container test
+      env:
+        DOCKER_BUILDKIT: 1
+      run: ./test/test.sh container.py --tag ${{ env.COMMIT }}
+
+    #
+    #
+    # Submit coveralls
+    - name: Submit Coveralls
+      env:
+        COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: goveralls -coverprofile=coverage.out -service=github
+
+    #
+    #
+    # Push to dockerhub
+    - name: Push to Docker Hub
+      uses: docker/build-push-action@v1
+      if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master'
+      with:
+        dockerfile: go/src/github.com/microservices-demo/payment/docker/payment/Dockerfile-release
+        path: go/src/github.com/microservices-demo/payment/docker/payment
+        username: ${{ secrets.DOCKER_USER }}
+        password: ${{ secrets.DOCKER_PASS }}
+        repository: ${{ env.GROUP }}/${{ env.REPO }}
+        tag_with_ref: true
+        tag_with_sha: true


### PR DESCRIPTION
PR to add github actions workflow.

Initially was going to move from using **gvt** to **go modules** (including a go version bump) as gvt is no longer maintained and seems to be very slow to pull dependencies. I ran into a couple of very minor issues with go modules so the currently this is wholly replicating the steps that travis CI does. 
Will move to go modules in a separate PR once github actions have been established.